### PR TITLE
removing empty arrays from array of values

### DIFF
--- a/lib/capistrano/tasks/env.rake
+++ b/lib/capistrano/tasks/env.rake
@@ -80,7 +80,7 @@ module Capistrano
           values = string.split("\n").map do |line|
             line.split(/:|\n/, 2).map(&:strip)
           end
-          values = values.reject { |v| v.empty? }
+          values.reject(&:empty?)
           Hash[values]
         end
 

--- a/lib/capistrano/tasks/env.rake
+++ b/lib/capistrano/tasks/env.rake
@@ -80,6 +80,7 @@ module Capistrano
           values = string.split("\n").map do |line|
             line.split(/:|\n/, 2).map(&:strip)
           end
+          values = values.reject { |v| v.empty? }
           Hash[values]
         end
 


### PR DESCRIPTION
When there are blank lines in the .env file, it results in creating empty array element [] in the array of values to be hashified, which throws an exception.  This simply removes the empty elements.
Thanks.
